### PR TITLE
add Atomist webhook to Travis

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -14,3 +14,19 @@ editor:
   parameters:
     - "atomistWebhookUrl": "https://webhook.atomist.com/atomist/travis"
 
+---
+kind: "operation"
+client: "com.atomist:rug"
+version: "1.0.0-20170816122823"
+editor:
+  name: "AddTravisWebhookEditor"
+  group: "atomist"
+  artifact: "enrollment-rugs"
+  version: "0.3.37"
+  origin:
+    repo: "git@github.com:atomisthq/enrollment-rugs"
+    branch: "master"
+    sha: "cc6a3b9"
+  parameters:
+    - "atomistWebhookUrl": "https://webhook.atomist.com/atomist/travis"
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,10 @@
 language: java
+notifications:
+  webhooks:
+    urls:
+    - 'https://webhook.atomist.com/atomist/travis'
+    on_cancel: always
+    on_error: always
+    on_start: always
+    on_failure: always
+    on_success: always


### PR DESCRIPTION
Created by Atomist Editor `AddTravisWebhookEditor`
```
---
kind: "operation"
client: "com.atomist:rug"
version: "1.0.0-20170816122823"
editor:
  name: "AddTravisWebhookEditor"
  group: "atomist"
  artifact: "enrollment-rugs"
  version: "0.3.37"
  origin:
    repo: "git@github.com:atomisthq/enrollment-rugs"
    branch: "master"
    sha: "cc6a3b9"
  parameters:
    - "atomistWebhookUrl": "https://webhook.atomist.com/atomist/travis"

```