### PR TITLE
Receive build notifications via Atomist

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -30,3 +30,19 @@ editor:
   parameters:
     - "atomistWebhookUrl": "https://webhook.atomist.com/atomist/travis"
 
+---
+kind: "operation"
+client: "com.atomist:rug"
+version: "1.0.0-20170816122823"
+editor:
+  name: "AddTravisWebhookEditor"
+  group: "atomist"
+  artifact: "enrollment-rugs"
+  version: "0.3.57"
+  origin:
+    repo: "git@github.com:atomisthq/enrollment-rugs"
+    branch: "master"
+    sha: "09e564a"
+  parameters:
+    - "atomistWebhookUrl": "https://webhook.atomist.com/atomist/travis/teams/T6RSY44Q4"
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,10 @@
 language: java
+notifications:
+  webhooks:
+    urls:
+    - 'https://webhook.atomist.com/travis/teams/T6RSY44Q4'
+    on_cancel: always
+    on_error: always
+    on_start: always
+    on_failure: always
+    on_success: always


### PR DESCRIPTION
Send build events to Atomist.

They'll be incorporated into GitHub push and PR notifications,
so you'll see dynamically updated build results along with your commits.
Look for them in this channel in Slack.

[Travis webhook documentation](https://docs.travis-ci.com/user/notifications/#Configuring-webhook-notifications)